### PR TITLE
add io as dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,4 +9,4 @@ description: The package contains reading and writing functions and conveninece
  JSON and XML files.
  The XML-related function are based on the work of Jarek Tuszynski at SAIC.
 categories: package
-depends: octave (>= 7.2.0)
+depends: octave (>= 7.2.0), io

--- a/readxml.m
+++ b/readxml.m
@@ -191,7 +191,6 @@ function DOMnode = getDOMnode(xmlfile)
     if isOctave() % Octave
         javaaddpath(fullfile(fileparts(mfilename('fullpath')),'xerces','xercesImpl.jar'));
         javaaddpath(fullfile(fileparts(mfilename('fullpath')),'xerces','xml-apis.jar'));
-        pkg('load','io');
 
         % read xml file using Octave function
         DOMnode = xmlread(xmlfile);

--- a/writexml.m
+++ b/writexml.m
@@ -156,7 +156,6 @@ function DOMnode = writexml(varargin)
     if isOctave() % Octave
         javaaddpath(fullfile(fileparts(mfilename('fullpath')),'xerces','xercesImpl.jar'));
         javaaddpath(fullfile(fileparts(mfilename('fullpath')),'xerces','xml-apis.jar'));
-        pkg('load','io');
 
         DOMnode = javaObject ("org.apache.xerces.dom.DocumentImpl");
         root = DOMnode.createElement (RootName);


### PR DESCRIPTION
I added io as a dependency as described in https://github.com/reprostat/fileio/issues/4?reload=1.
This also means that io do not need to be loaded from `readxml.m`.

```
pkg install "./fileio.tar.gz"
error: the following dependencies were unsatisfied:
   fileio needs io >= 0.0.0
octave:2> pkg install -forge io
...
For information about changes from previous versions of the io package, run 'news io'.
octave:3> pkg install "./fileio.tar.gz"
warning: doc_cache_create: unusable help text found in file 'isAbsolutePath'
warning: called from
    doc_cache_create>handle_function at line 98 column 5
    doc_cache_create>create_cache at line 118 column 36
    gen_doc_cache_in_dir>@<anonymous> at line 150 column 20
    doc_cache_create>gen_doc_cache_in_dir at line 151 column 9
    doc_cache_create at line 62 column 12
    install>generate_lookfor_cache at line 836 column 5
    install at line 241 column 7
    pkg at line 619 column 9

warning: doc_cache_create: unusable help text found in file 'readLink'
warning: called from
    doc_cache_create>handle_function at line 98 column 5
    doc_cache_create>create_cache at line 118 column 36
    gen_doc_cache_in_dir>@<anonymous> at line 150 column 20
    doc_cache_create>gen_doc_cache_in_dir at line 151 column 9
    doc_cache_create at line 62 column 12
    install>generate_lookfor_cache at line 836 column 5
    install at line 241 column 7
    pkg at line 619 column 9

warning: doc_cache_create: unusable help text found in file 'strreps'
warning: called from
    doc_cache_create>handle_function at line 98 column 5
    doc_cache_create>create_cache at line 118 column 36
    gen_doc_cache_in_dir>@<anonymous> at line 150 column 20
    doc_cache_create>gen_doc_cache_in_dir at line 151 column 9
    doc_cache_create at line 62 column 12
    install>generate_lookfor_cache at line 836 column 5
    install at line 241 column 7
    pkg at line 619 column 9

octave:4> pkg test fileio
Testing functions in package 'fileio':

Integrated test scripts:

                                                                                  [ CPU    /  CLOCK ]
  ..l/share/octave/api-v59/packages/fileio-1.2.3/isAbsolutePath.m  pass    2/2    [ 0.006s /  0.006s]
  ../.local/share/octave/api-v59/packages/fileio-1.2.3/isOctave.m  pass    1/1    [ 0.003s /  0.003s]
  ../.local/share/octave/api-v59/packages/fileio-1.2.3/jsonread.m  pass    1/1    [ 0.020s /  0.021s]
  ...local/share/octave/api-v59/packages/fileio-1.2.3/jsonwrite.m  pass    2/2    [ 0.036s /  0.037s]
  ../.local/share/octave/api-v59/packages/fileio-1.2.3/readLink.m  pass    2/2    [ 0.032s /  0.033s]
  ..s/.local/share/octave/api-v59/packages/fileio-1.2.3/readxml.m  pass    1/1    [ 0.177s /  0.124s]
  ../.local/share/octave/api-v59/packages/fileio-1.2.3/writexml.m  pass    2/2    [ 0.250s /  0.158s]

Fixed test scripts:

                                                        total time (CPU / CLOCK)  [   0.6s /    0.4s]
Summary:

  PASS                               11
  FAIL                                0

See the file /home/rasmus/Downloads/fntests.log for additional details.

1 (of 8) .m files have no tests.

Please help improve Octave by contributing tests for these files
(see the list in the file /home/rasmus/Downloads/fntests.log).
```